### PR TITLE
Update to Go 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.22'
+        go-version: '1.23'
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jrh3k5/freestuff-api-go
 
-go 1.22.0
+go 1.23.0
 
 toolchain go1.23.3
 


### PR DESCRIPTION
There are two dependency update PRs that are failing because they require Go 1.23.